### PR TITLE
Update deps, fix fireball crash

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,11 +4,11 @@ org.gradle.jvmargs=-Xmx1G
 # Fabric Properties
 	# check these on https://fabricmc.net/use
 	minecraft_version=1.16.5
-	yarn_mappings=1.16.5+build.3
-	loader_version=0.11.1
+	yarn_mappings=1.16.5+build.5
+	loader_version=0.11.2
 
-	#Fabric api
-	fabric_version=0.30.0+1.16
+	# Fabric api
+	fabric_version=0.31.0+1.16
 
 # Mod Properties
 	mod_version = 1.0.0

--- a/src/main/java/com/github/fabricservertools/deltalogger/mixins/events/FireballEntityMixin.java
+++ b/src/main/java/com/github/fabricservertools/deltalogger/mixins/events/FireballEntityMixin.java
@@ -1,21 +1,12 @@
 package com.github.fabricservertools.deltalogger.mixins.events;
 
-import com.github.fabricservertools.deltalogger.DatabaseManager;
-import com.github.fabricservertools.deltalogger.dao.EntityDAO;
-import com.github.fabricservertools.deltalogger.events.CreeperExplodeCallback;
 import com.github.fabricservertools.deltalogger.events.FireballExplodeCallback;
-import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityType;
 import net.minecraft.entity.LivingEntity;
-import net.minecraft.entity.mob.CreeperEntity;
-import net.minecraft.entity.mob.GhastEntity;
-import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.entity.projectile.AbstractFireballEntity;
 import net.minecraft.entity.projectile.FireballEntity;
 import net.minecraft.util.ActionResult;
 import net.minecraft.util.hit.HitResult;
-import net.minecraft.util.registry.Registry;
-import net.minecraft.world.GameRules;
 import net.minecraft.world.World;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
@@ -29,21 +20,21 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 // onCollision
 public class FireballEntityMixin extends AbstractFireballEntity {
-	public FireballEntityMixin(EntityType<? extends AbstractFireballEntity> entityType, LivingEntity livingEntity,
-							   double d, double e, double f, World world) {
-		super(entityType, livingEntity, d, e, f, world);
-	}
+    public FireballEntityMixin(EntityType<? extends AbstractFireballEntity> entityType, LivingEntity livingEntity,
+                               double d, double e, double f, World world) {
+        super(entityType, livingEntity, d, e, f, world);
+    }
 
-	@Inject(
-			method = "onCollision",
-			at = @At(value = "INVOKE", target = "Lnet/minecraft/world/World;createExplosion(Lnet/minecraft/entity/Entity;DDDFZLnet/minecraft/world/explosion/Explosion$DestructionType;)Lnet/minecraft/world/explosion/Explosion;"),
-			cancellable = true
-	)
-	private void tryLogFireballExplosion(HitResult hit, CallbackInfo info) {
-		ActionResult result = FireballExplodeCallback.EVENT.invoker().explode((FireballEntity) (Object) this, hit);
+    @Inject(
+            method = "onCollision",
+            at = @At(value = "INVOKE", target = "Lnet/minecraft/world/World;createExplosion(Lnet/minecraft/entity/Entity;DDDFZLnet/minecraft/world/explosion/Explosion$DestructionType;)Lnet/minecraft/world/explosion/Explosion;"),
+            cancellable = true
+    )
+    private void tryLogFireballExplosion(HitResult hit, CallbackInfo info) {
+        ActionResult result = FireballExplodeCallback.EVENT.invoker().explode((FireballEntity) (Object) this, hit);
 
-		if (result != ActionResult.PASS) {
-			info.cancel();
-		}
-	}
+        if (result != ActionResult.PASS) {
+            info.cancel();
+        }
+    }
 }

--- a/src/main/java/com/github/fabricservertools/deltalogger/mixins/events/FireballEntityMixin.java
+++ b/src/main/java/com/github/fabricservertools/deltalogger/mixins/events/FireballEntityMixin.java
@@ -3,6 +3,7 @@ package com.github.fabricservertools.deltalogger.mixins.events;
 import com.github.fabricservertools.deltalogger.DatabaseManager;
 import com.github.fabricservertools.deltalogger.dao.EntityDAO;
 import com.github.fabricservertools.deltalogger.events.CreeperExplodeCallback;
+import com.github.fabricservertools.deltalogger.events.FireballExplodeCallback;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityType;
 import net.minecraft.entity.LivingEntity;
@@ -39,7 +40,7 @@ public class FireballEntityMixin extends AbstractFireballEntity {
 			cancellable = true
 	)
 	private void tryLogFireballExplosion(HitResult hit, CallbackInfo info) {
-		ActionResult result = CreeperExplodeCallback.EVENT.invoker().explode((CreeperEntity) (Object) this);
+		ActionResult result = FireballExplodeCallback.EVENT.invoker().explode((FireballEntity) (Object) this, hit);
 
 		if (result != ActionResult.PASS) {
 			info.cancel();


### PR DESCRIPTION
This commit fixes a copy-paste error in the fireball explosion mixin, which had its body copied from the creeper explosion mixin.