### PR TITLE
Reset tracked container when the screen handler uuid changes

### DIFF
--- a/src/main/java/com/github/fabricservertools/deltalogger/mixins/ServerPlayNetworkHandlerMixin.java
+++ b/src/main/java/com/github/fabricservertools/deltalogger/mixins/ServerPlayNetworkHandlerMixin.java
@@ -70,7 +70,11 @@ public abstract class ServerPlayNetworkHandlerMixin {
     public void onSlotClickHead(ClickSlotC2SPacket packet, CallbackInfo info) {
         UUID uuid = ((NbtUuid) player.currentScreenHandler).getNbtUuid();
 
-        if (uuid != this.screenHandlerUUID) commit();
+        if (uuid != this.screenHandlerUUID) {
+            commit();
+            tracked = null;
+        }
+
         this.screenHandlerUUID = uuid;
 
         if (uuid != null) {


### PR DESCRIPTION
Can't guarantee that this will fix the kick issue because I can't reproduce it, but it seems like the most likely culprit. 