### PR TITLE
Minor fixes for search subcommand

### DIFF
--- a/src/main/java/com/github/fabricservertools/deltalogger/command/search/ActionSuggestionProvider.java
+++ b/src/main/java/com/github/fabricservertools/deltalogger/command/search/ActionSuggestionProvider.java
@@ -16,8 +16,9 @@ public class ActionSuggestionProvider implements SuggestionProvider<ServerComman
 		String current = builder.getRemaining().toLowerCase();
 
 		for (EventTypes actions : EventTypes.values()) {
-			if (actions.name().contains(current)) {
-				builder.suggest(actions.name().toLowerCase());
+			String name = actions.name().toLowerCase();
+			if (name.contains(current)) {
+				builder.suggest(name);
 			}
 		}
 		return builder.buildFuture();

--- a/src/main/java/com/github/fabricservertools/deltalogger/command/search/CriteriumParser.java
+++ b/src/main/java/com/github/fabricservertools/deltalogger/command/search/CriteriumParser.java
@@ -111,14 +111,14 @@ public class CriteriumParser implements SuggestionProvider<ServerCommandSource> 
 	private static class Suggestor {
 		boolean useSuggestionProvider = false;
 		private SuggestionProvider<ServerCommandSource> suggestionProvider;
-		private ArgumentType argumentType;
+		private ArgumentType<?> argumentType;
 
 		public Suggestor(SuggestionProvider<ServerCommandSource> suggestionProvider) {
 			this.suggestionProvider = suggestionProvider;
 			this.useSuggestionProvider = true;
 		}
 
-		public Suggestor(ArgumentType argumentType) {
+		public Suggestor(ArgumentType<?> argumentType) {
 			this.argumentType = argumentType;
 		}
 

--- a/src/main/java/com/github/fabricservertools/deltalogger/command/search/CriteriumParser.java
+++ b/src/main/java/com/github/fabricservertools/deltalogger/command/search/CriteriumParser.java
@@ -11,6 +11,7 @@ import com.mojang.brigadier.suggestion.SuggestionProvider;
 import com.mojang.brigadier.suggestion.Suggestions;
 import com.mojang.brigadier.suggestion.SuggestionsBuilder;
 import net.minecraft.command.argument.BlockStateArgumentType;
+import net.minecraft.command.argument.ItemStackArgumentType;
 import net.minecraft.command.argument.DimensionArgumentType;
 import net.minecraft.command.argument.GameProfileArgumentType;
 import net.minecraft.server.command.ServerCommandSource;
@@ -34,6 +35,7 @@ public class CriteriumParser implements SuggestionProvider<ServerCommandSource> 
 		criteriumSuggestors.put("target", new Suggestor(GameProfileArgumentType.gameProfile()));
 		criteriumSuggestors.put("range", new Suggestor(IntegerArgumentType.integer()));
 		criteriumSuggestors.put("block", new Suggestor(BlockStateArgumentType.blockState()));
+		criteriumSuggestors.put("item", new Suggestor(ItemStackArgumentType.itemStack()));
 		criteriumSuggestors.put("dimension", new Suggestor(DimensionArgumentType.dimension()));
 		criteriumSuggestors.put("limit", new Suggestor(IntegerArgumentType.integer()));
 		this.criteria = criteriumSuggestors.keySet();

--- a/src/main/java/com/github/fabricservertools/deltalogger/command/search/SearchCommand.java
+++ b/src/main/java/com/github/fabricservertools/deltalogger/command/search/SearchCommand.java
@@ -6,8 +6,11 @@ import com.mojang.brigadier.arguments.StringArgumentType;
 import com.mojang.brigadier.context.CommandContext;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import com.mojang.brigadier.tree.LiteralCommandNode;
+
+import net.minecraft.block.Block;
 import net.minecraft.command.argument.BlockStateArgument;
 import net.minecraft.command.argument.GameProfileArgumentType;
+import net.minecraft.command.argument.ItemStackArgument;
 import net.minecraft.server.command.ServerCommandSource;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.text.MutableText;
@@ -69,6 +72,15 @@ public class SearchCommand {
 					+ Registry.BLOCK.getId(block.getBlockState().getBlock()).toString() + "\") ";
 			sqlContainer += "AND CT.item_type = (SELECT id FROM registry WHERE `name` = \""
 					+ Registry.BLOCK.getId(block.getBlockState().getBlock()).toString() + "\") ";
+		}
+
+		if (propertyMap.containsKey("item")) {
+			ItemStackArgument item = (ItemStackArgument)propertyMap.get("item");
+			Block block = Block.getBlockFromItem(item.getItem());
+			sqlPlace += "AND CT.item_type = (SELECT id FROM registry WHERE `name` = \""
+					+ Registry.BLOCK.getId(block).toString() + "\") ";
+			sqlContainer += "AND CT.item_type = (SELECT id FROM registry WHERE `name` = \""
+					+ Registry.ITEM.getId(item.getItem()).toString() + "\") ";
 		}
 
 		//range or pos

--- a/src/main/java/com/github/fabricservertools/deltalogger/command/search/SearchCommand.java
+++ b/src/main/java/com/github/fabricservertools/deltalogger/command/search/SearchCommand.java
@@ -111,7 +111,7 @@ public class SearchCommand {
 				} else if (action.contains("added")) {
 					sqlContainer += "AND item_count > 0 ";
 					sendTransactions(scs, sqlContainer, limit);
-				} else if (action.contains("removed")) {
+				} else if (action.contains("taken")) {
 					sqlContainer += "AND item_count < 0 ";
 					sendTransactions(scs, sqlContainer, limit);
 				} else if (action.contains("grief")) {

--- a/src/main/java/com/github/fabricservertools/deltalogger/command/search/SearchCommand.java
+++ b/src/main/java/com/github/fabricservertools/deltalogger/command/search/SearchCommand.java
@@ -2,9 +2,11 @@ package com.github.fabricservertools.deltalogger.command.search;
 
 import com.github.fabricservertools.deltalogger.Chat;
 import com.github.fabricservertools.deltalogger.dao.DAO;
+import com.mojang.brigadier.LiteralMessage;
 import com.mojang.brigadier.arguments.StringArgumentType;
 import com.mojang.brigadier.context.CommandContext;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
+import com.mojang.brigadier.exceptions.SimpleCommandExceptionType;
 import com.mojang.brigadier.tree.LiteralCommandNode;
 
 import net.minecraft.block.Block;
@@ -112,27 +114,27 @@ public class SearchCommand {
 		// Check for an action and only query the relevant tables
 		if (propertyMap.containsKey("action")) {
 			String action = (String) propertyMap.get("action");
-			if (!action.contains("everything")) {
-
-				if (action.contains("placed")) {
-					sqlPlace += "AND placed = 1 ";
-					sendPlacements(scs, sqlPlace, limit);
-				} else if (action.contains("broken")) {
-					sqlPlace += "AND placed = 0 ";
-					sendPlacements(scs, sqlPlace, limit);
-				} else if (action.contains("added")) {
-					sqlContainer += "AND item_count > 0 ";
-					sendTransactions(scs, sqlContainer, limit);
-				} else if (action.contains("taken")) {
-					sqlContainer += "AND item_count < 0 ";
-					sendTransactions(scs, sqlContainer, limit);
-				} else if (action.contains("grief")) {
-					sendGrief(scs, sqlGrief, limit);
-				}
-			} else {
+			if (action.equals("placed")) {
+				sqlPlace += "AND placed = 1 ";
+				sendPlacements(scs, sqlPlace, limit);
+			} else if (action.equals("broken")) {
+				sqlPlace += "AND placed = 0 ";
+				sendPlacements(scs, sqlPlace, limit);
+			} else if (action.equals("added")) {
+				sqlContainer += "AND item_count > 0 ";
+				sendTransactions(scs, sqlContainer, limit);
+			} else if (action.equals("taken")) {
+				sqlContainer += "AND item_count < 0 ";
+				sendTransactions(scs, sqlContainer, limit);
+			} else if (action.equals("grief")) {
+				sendGrief(scs, sqlGrief, limit);
+			} else if (action.equals("everything")) {
 				sendGrief(scs, sqlGrief, limit);
 				sendTransactions(scs, sqlContainer, limit);
 				sendPlacements(scs, sqlPlace, limit);
+			} else {
+				throw new SimpleCommandExceptionType(new LiteralMessage("Invalid action: " + action))
+						.create();
 			}
 		} else {
 			sendTransactions(scs, sqlContainer, limit);


### PR DESCRIPTION
This:
- Makes suggestions for action types actually show up
- Causes an error when entering an invalid action type
- Renames the `removed` action to `taken` to match up with the name of the actual event
- Adds a new `item:` selector (which is basically identical to `block:`)